### PR TITLE
Implement `tomato.dummy` and `tomato.biologic` monitor scripts

### DIFF
--- a/aiida_calcmonitor/calculations/calcjob_monitor.py
+++ b/aiida_calcmonitor/calculations/calcjob_monitor.py
@@ -63,11 +63,16 @@ class CalcjobMonitor(CalcJob):
         calcinfo.codes_info = [codeinfo]
         calcinfo.local_copy_list = []
         calcinfo.retrieve_list = [self.metadata.options.output_filename]
+        calcinfo.retrieve_temporary_list = []
         
         for node in self.inputs.monitor_protocols.values():
             for filepath in node.get_dict()['retrieve']:
                 if filepath not in calcinfo.retrieve_list:
                     calcinfo.retrieve_list.append(filepath)
+        for node in self.inputs.monitor_protocols.values():
+            for filepath in node.get_dict()['retrieve_temporary']:
+                if filepath not in calcinfo.retrieve_temporary_list:
+                    calcinfo.retrieve_temporary_list.append(filepath)
 
         instructions = {}
         instructions['calcjob_uuid'] = self.inputs.monitor_folder.creator.uuid

--- a/aiida_calcmonitor/data/monitors/monitor_tomato.py
+++ b/aiida_calcmonitor/data/monitors/monitor_tomato.py
@@ -1,0 +1,29 @@
+"""
+Monitor example for the toy model.
+"""
+import os
+import json
+from aiida_calcmonitor.data.monitors.monitor_base import MonitorBase
+
+class MonitorTomatoDummy(MonitorBase):  # pylint: disable=too-many-ancestors
+    """Example of monitor for a tomato's dummy job."""
+
+    def monitor_analysis(self):
+        sources = self['sources']
+        options = self['options']
+
+        filepath = sources['output']['filepath']
+
+        with open(filepath, "rb") as fileobj:
+            jsdata = json.load(fileobj)
+        
+        last_ts = jsdata["steps"][0]["data"][-1]
+        last_val = last_ts["raw"]["value"]
+        print(f'value under control: {last_val}')
+
+        max_val = options.get("maximum_value", 10)
+        if last_val < max_val:
+            return None
+        else:
+            print('value exceeded!')
+            return 'value exceeded!'

--- a/aiida_calcmonitor/data/monitors/monitor_tomato.py
+++ b/aiida_calcmonitor/data/monitors/monitor_tomato.py
@@ -60,43 +60,34 @@ class MonitorTomatoBioLogic(MonitorBase):
                 I.append(ts["raw"]["I"]["n"])
                 cn.append(ts["raw"]["cycle number"])
             t0 = uts[0]
-
             # convert to numpy arrays
             t = np.array(uts) - t0
             Ewe = np.array(Ewe)
             I = np.array(I)
             cn = np.array(cn)
-
             # find indices of sign changes in I
             idx = np.where(np.diff(np.sign(I)) != 0)[0]
-
-            
-            # integrate and store charge and discharge currents, store cycle indices
+            # integrate and store charge and discharge currents
             for ii, ie in enumerate(idx[1:]):
                 i0 = idx[ii]
                 q = np.trapz(I[i0:ie], t[i0:ie])
                 if q > 0:
                     Qc.append(q)
                 else:
-                    Qd.append(abs(q))
-            
+                    Qd.append(abs(q))            
             if discharge:
                 return np.array(Qd)
             else:
                 return np.array(Qc)
-            
 
         sources = self['sources']
         options = self['options']
-
         filepath = sources['output']['filepath']
-
         if not os.path.isfile(filepath):
             return None
-
         with open(filepath, "rb") as fileobj:
             jsdata = json.load(fileobj)
-        
+            
         # calculate data based on check_type
         if options.get("check_type") == "discharge_capacity":
             Qs = get_capacities(jsdata["steps"][0]["data"], discharge=True)

--- a/aiida_calcmonitor/data/monitors/monitor_tomato.py
+++ b/aiida_calcmonitor/data/monitors/monitor_tomato.py
@@ -51,7 +51,7 @@ class MonitorTomatoBioLogic(MonitorBase):
 
     def monitor_analysis(self):
 
-        def get_capacities(data: list[dict], discharge=True) -> list[float]:
+        def get_capacities(data, discharge=True):
             uts, Ewe, I, cn,  Qc, Qd = [], [], [], [], [], []
             # extract raw data
             for ts in data:

--- a/aiida_calcmonitor/data/monitors/monitor_tomato.py
+++ b/aiida_calcmonitor/data/monitors/monitor_tomato.py
@@ -14,11 +14,14 @@ class MonitorTomatoDummy(MonitorBase):  # pylint: disable=too-many-ancestors
 
         filepath = sources['output']['filepath']
 
+        if not os.path.isfile(filepath):
+            return None
+
         with open(filepath, "rb") as fileobj:
             jsdata = json.load(fileobj)
         
         last_ts = jsdata["steps"][0]["data"][-1]
-        last_val = last_ts["raw"]["value"]
+        last_val = last_ts["raw"]["value"]["n"]
         print(f'value under control: {last_val}')
 
         max_val = options.get("maximum_value", 10)

--- a/aiida_calcmonitor/data/monitors/monitor_tomato.py
+++ b/aiida_calcmonitor/data/monitors/monitor_tomato.py
@@ -3,6 +3,8 @@ Monitor example for the toy model.
 """
 import os
 import json
+import numpy as np
+import itertools
 from aiida_calcmonitor.data.monitors.monitor_base import MonitorBase
 
 class MonitorTomatoDummy(MonitorBase):  # pylint: disable=too-many-ancestors
@@ -30,3 +32,89 @@ class MonitorTomatoDummy(MonitorBase):  # pylint: disable=too-many-ancestors
         else:
             print('value exceeded!')
             return 'value exceeded!'
+
+
+class MonitorTomatoBioLogic(MonitorBase):
+    """
+    Example of monitor for a tomato's biologic job.
+    
+    Structure of ``options``:
+
+    .. code-block:: yaml
+
+        options:
+            check_type: str = Literal["discharge_capacity", "charge_capacity", "voltage_drift"]
+            previous_cycles: int = 2
+            threshold: float = 0.8
+
+    """
+
+    def monitor_analysis(self):
+
+        def get_capacities(data: list[dict], discharge=True) -> list[float]:
+            uts, Ewe, I, cn,  Qc, Qd = [], [], [], [], [], []
+            # extract raw data
+            for ts in data:
+                uts.append(ts["uts"])
+                Ewe.append(ts["raw"]["Ewe"]["n"])
+                I.append(ts["raw"]["I"]["n"])
+                cn.append(ts["raw"]["cycle number"])
+            t0 = uts[0]
+
+            # convert to numpy arrays
+            t = np.array(uts) - t0
+            Ewe = np.array(Ewe)
+            I = np.array(I)
+            cn = np.array(cn)
+
+            # find indices of sign changes in I
+            idx = np.where(np.diff(np.sign(I)) != 0)[0]
+
+            
+            # integrate and store charge and discharge currents, store cycle indices
+            for ii, ie in enumerate(idx[1:]):
+                i0 = idx[ii]
+                q = np.trapz(I[i0:ie], t[i0:ie])
+                if q > 0:
+                    Qc.append(q)
+                else:
+                    Qd.append(abs(q))
+            
+            if discharge:
+                return np.array(Qd)
+            else:
+                return np.array(Qc)
+            
+
+        sources = self['sources']
+        options = self['options']
+
+        filepath = sources['output']['filepath']
+
+        if not os.path.isfile(filepath):
+            return None
+
+        with open(filepath, "rb") as fileobj:
+            jsdata = json.load(fileobj)
+        
+        # calculate data based on check_type
+        if options.get("check_type") == "discharge_capacity":
+            Qs = get_capacities(jsdata["steps"][0]["data"], discharge=True)
+        elif options.get("check_type") == "charge_capacity":
+            Qs = get_capacities(jsdata["steps"][0]["data"], discharge=False)
+        else:
+            raise RuntimeError(f"Provided {options.get('check_type')=} not understood.")
+        
+        # trigger conditions based on check_type
+        if options.get("check_type") in {"discharge_capacity", "charge_capacity"}:
+            print(f"Completed {len(Qs)} cycles.")
+            if len(Qs) >= options.get("previous_cycles") + 1:
+                below_thresh = Qs < options.get("threshold", 0.8) * Qs[0]
+                print(below_thresh)
+                below_groups = [sum(1 for _ in g) for k, g in itertools.groupby(below_thresh) if k]
+                for g in below_groups:
+                    if g > options.get("previous_cycles"):
+                        return f'Below threshold for {g} cycles!'
+            return None
+        else:
+            raise RuntimeError(f"Provided {options.get('check_type')=} not understood.")

--- a/aiida_calcmonitor/data/monitors/monitor_tomato.py
+++ b/aiida_calcmonitor/data/monitors/monitor_tomato.py
@@ -44,7 +44,7 @@ class MonitorTomatoBioLogic(MonitorBase):
 
         options:
             check_type: str = Literal["discharge_capacity", "charge_capacity", "voltage_drift"]
-            previous_cycles: int = 2
+            consecutive_cycles: int = 2
             threshold: float = 0.8
 
     """
@@ -108,12 +108,11 @@ class MonitorTomatoBioLogic(MonitorBase):
         # trigger conditions based on check_type
         if options.get("check_type") in {"discharge_capacity", "charge_capacity"}:
             print(f"Completed {len(Qs)} cycles.")
-            if len(Qs) >= options.get("previous_cycles") + 1:
+            if len(Qs) >= options.get("consecutive_cycles") + 1:
                 below_thresh = Qs < options.get("threshold", 0.8) * Qs[0]
-                print(below_thresh)
                 below_groups = [sum(1 for _ in g) for k, g in itertools.groupby(below_thresh) if k]
                 for g in below_groups:
-                    if g > options.get("previous_cycles"):
+                    if g > options.get("consecutive_cycles"):
                         return f'Below threshold for {g} cycles!'
             return None
         else:

--- a/aiida_calcmonitor/parsers/cycler_monitor.py
+++ b/aiida_calcmonitor/parsers/cycler_monitor.py
@@ -43,31 +43,34 @@ class TomatoMonitorParser(Parser):
         :returns: an exit code, if parsing fails (or nothing if parsing succeeds)
         """
         retrieved_temporary_folder = kwargs["retrieved_temporary_folder"]
-        output_json_filename = self.node.get_option("output_filename") + ".json"
-        output_zip_filename = os.path.join(
-            retrieved_temporary_folder, self.node.get_option("output_filename") + ".zip"
-        )
+        #output_json_filename = self.node.get_option("output_filename") + ".json"
+        output_json_filename = 'results.json'
+        output_zip_filename = 'results.zip'
+#        output_json_filename = self.node.get_option("output_filename") + ".json"
+#        output_zip_filename = os.path.join(
+#            retrieved_temporary_folder, self.node.get_option("output_filename") + ".zip"
+#        )
 
         files_retrieved = self.retrieved.list_object_names()
         output_dict = {}
 
         # Check that zip file is present
-        if os.path.isfile(output_zip_filename):
-            try:
-                self.logger.debug(f"Storing '{output_zip_filename}'")
-                output_raw_data_node = SinglefileData(output_zip_filename)
-                output_dict["raw_data"] = output_raw_data_node
-                output_raw_data_node_created = True
-            except Exception:
-                self.logger.warning(
-                    f"The raw data zip file '{output_zip_filename}' could not be read."
-                )
-                output_raw_data_node_created = False
-        else:
-            self.logger.warning(
-                f"The raw data zip file '{output_zip_filename}' is missing."
-            )
-            output_raw_data_node_created = False
+#        if os.path.isfile(output_zip_filename):
+#            try:
+#                self.logger.debug(f"Storing '{output_zip_filename}'")
+#                output_raw_data_node = SinglefileData(output_zip_filename)
+#                output_dict["raw_data"] = output_raw_data_node
+#                output_raw_data_node_created = True
+#            except Exception:
+#                self.logger.warning(
+#                    f"The raw data zip file '{output_zip_filename}' could not be read."
+#                )
+#                output_raw_data_node_created = False
+#        else:
+#            self.logger.warning(
+#                f"The raw data zip file '{output_zip_filename}' is missing."
+#            )
+#            output_raw_data_node_created = False
 
         # Check that json file is present
         if not output_json_filename in files_retrieved:
@@ -93,8 +96,8 @@ class TomatoMonitorParser(Parser):
         self.out('redirected_outputs', output_dict)
 
         # check that the zip file is there. Is it already stored in a SinglefileData node??
-        if not output_raw_data_node_created:
-            return self.exit_codes.ERROR_MISSING_ZIP_FILE
+ #       if not output_raw_data_node_created:
+ #           return self.exit_codes.ERROR_MISSING_ZIP_FILE
 
         # TODO: other checks:  jobs completed with error or cancelled
         # ......

--- a/aiida_calcmonitor/utils/calcjob_monitor.py
+++ b/aiida_calcmonitor/utils/calcjob_monitor.py
@@ -73,7 +73,8 @@ def monitor_calcjob(input_filename):
         for monitor_node in monitor_list:
             result = monitor_node.monitor_analysis()
             if result is not None:
-                print(f'SIGNAL FROM MONITOR `{monitor_node.entry_point.name}`:\n{result}')
+                # print(f'SIGNAL FROM MONITOR `{monitor_node.entry_point.name}`:\n{result}')
+                print(f'SIGNAL FROM MONITOR:\n{result}')
                 runner = CliRunner()
                 result = runner.invoke(cmd_process.process_kill, [calcjob_uuid])
 
@@ -83,7 +84,7 @@ def monitor_calcjob(input_filename):
 
     # Get the list of all files to be retrieved
     retrieve_list = []
-    for monitor_node in monitor_list():
+    for monitor_node in monitor_list:
         for filepath in monitor_node.get_dict()['retrieve']:
             if filepath not in retrieve_list:
                 retrieve_list.append(filepath)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ keywords = ["aiida", "plugin"]
 requires-python = ">=3.8"
 dependencies = [
     "aiida-core>=1.6,<3",
+    "numpy"
 ]
 
 [project.urls]
@@ -58,6 +59,7 @@ docs = [
 [project.entry-points."aiida.data"]
 "calcmonitor.monitor.toymodel" = "aiida_calcmonitor.data.monitors.monitor_toymodel:MonitorToymodel"
 "calcmonitor.monitor.tomatodummy" = "aiida_calcmonitor.data.monitors.monitor_tomato:MonitorTomatoDummy"
+"calcmonitor.monitor.tomatobiologic" = "aiida_calcmonitor.data.monitors.monitor_tomato:MonitorTomatoBioLogic"
 
 [project.entry-points."aiida.cmdline.data"]
 "aiida-calcmonitor" = "aiida_calcmonitor.cli:root"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ docs = [
 
 [project.entry-points."aiida.data"]
 "calcmonitor.monitor.toymodel" = "aiida_calcmonitor.data.monitors.monitor_toymodel:MonitorToymodel"
+"calcmonitor.monitor.tomatodummy" = "aiida_calcmonitor.data.monitors.monitor_tomato:MonitorTomatoDummy"
 
 [project.entry-points."aiida.cmdline.data"]
 "aiida-calcmonitor" = "aiida_calcmonitor.cli:root"


### PR DESCRIPTION
This PR will implement a monitor script for the `tomato.dummy` device.

The monitor script looks for the `datagram` json file created by a snapshot, which should be in `sources['output']['filepath']`, reads that file, gets the last value, and compares it to a threshold in `options['maximum_value']: int = 10`.

I'm not sure how to set-up a tomato job. However, the yaml for this job should looks something like:

```
version: "0.2"
sample:
    name: samplename
method:
  - device: "worker"
    technique: "sequential"
    time: 1800
    delay: 5
tomato:
    snapshot:
        frequency: 10
```
This will need https://github.com/dgbowl/tomato/pull/37 merged before it will work.

Pinging @ramirezfranciscof and @lorisercole for more details.